### PR TITLE
Only fetch specific columns from sales_order

### DIFF
--- a/Model/Api/Order.php
+++ b/Model/Api/Order.php
@@ -564,6 +564,11 @@ class Order
             ['neq' => \Magento\Sales\Model\Order::STATE_CANCELED],
             ['neq' => \Magento\Sales\Model\Order::STATE_CLOSED]])
             ->addAttributeToFilter('customer_email', ['eq' => $order->getCustomerEmail()]);
+        
+        $orderCollection
+            ->getSelect()
+            ->reset(\Zend_Db_Select::COLUMNS)
+            ->columns(['grand_total', 'total_refunded', 'total_canceled']);
 
         $totalOrders = 0;
         $totalAmountSpent = 0;


### PR DESCRIPTION
I found that these queries are quite expensive (~1.3 seconds per customer) against production dataset.

Limiting the number of column drastically reduced query time to ~0.3 seconds per customer.

These are the only columns that are actually used